### PR TITLE
[RFC][NI] Change locale translate query

### DIFF
--- a/lib/utils/spreadsheet.js
+++ b/lib/utils/spreadsheet.js
@@ -1,6 +1,15 @@
 /* global module */
 module.exports = {
   googleTranslateFormula: function(sentence, source, target) {
-    return `=GOOGLETRANSLATE("${sentence}", "${source}", "${target}")`;
+    return `=GOOGLETRANSLATE("${sentence}", "${_getISO6391Language(source)}", "${_getISO6391Language(target)}")`;
   }
 };
+
+function _getISO6391Language(language = '') {
+  // This is defined in google translate API: https://cloud.google.com/translate/docs/languages
+  const languageCodeExceptions = ['haw', 'hmn', 'zh-cn', 'zh-tw'];
+
+  return languageCodeExceptions.includes(language.toLowerCase()) 
+    ? language 
+    : language.split('-')[0];
+}


### PR DESCRIPTION
# Why?
We all know we've had problems using this with language code google does not recognize (things like `pl-pl` and `nl-nl`). I was tired of this.

# What this does
This changes the util that generates the google translate formula so we are compliant with google translate api specifications. 

# How was this working before? 
It happens that google translate api is very permissive and *accepts* some common locale identifiers that are not according to the standard

# Context
Google translate API uses ISO693-1, this means it uses language identifiers and does not
distinguist language variants. `pt-br` works but is the same as `pt-pt`, same happens for english, as this standard only cares about the *mother language* (except a few cases that are handled).

More details: https://cloud.google.com/translate/docs/languages